### PR TITLE
texelutil: Fix missing headerfile includes

### DIFF
--- a/app/texelutil/spsa.cpp
+++ b/app/texelutil/spsa.cpp
@@ -32,6 +32,7 @@
 #include <memory>
 #include <iostream>
 #include <limits>
+#include <fstream>
 
 #ifdef USE_GSL
 


### PR DESCRIPTION
Hello, Peter.

Compilation of texelutil failed because the `<fstream>` header file was not included, so I fixed it.
I would be happy if you merge it to master.

```
[main] Building folder: texel 
[build] Starting build
[proc] Executing command: /usr/bin/cmake --build /home/stepney141/board-games/texel/build --config Debug --target texelutil --
[build] [1/2  50% :: 0.793] Building CXX object app/texelutil/CMakeFiles/texelutil.dir/spsa.cpp.o
[build] FAILED: app/texelutil/CMakeFiles/texelutil.dir/spsa.cpp.o 
[build] /usr/bin/clang++ -DUSE_GSL -I/home/stepney141/board-games/texel/lib/texelutillib/. -I/home/stepney141/board-games/texel/lib/texelutillib/pg -I/home/stepney141/board-games/texel/lib/texellib/. -I/home/stepney141/board-games/texel/lib/texellib/book -I/home/stepney141/board-games/texel/lib/texellib/debug -I/home/stepney141/board-games/texel/lib/texellib/hw -I/home/stepney141/board-games/texel/lib/texellib/nn -I/home/stepney141/board-games/texel/lib/texellib/tb -I/home/stepney141/board-games/texel/lib/texellib/util -g -std=c++11 -Wno-misleading-indentation -Wno-unused-result -Wno-psabi -fno-stack-protector -MD -MT app/texelutil/CMakeFiles/texelutil.dir/spsa.cpp.o -MF app/texelutil/CMakeFiles/texelutil.dir/spsa.cpp.o.d -o app/texelutil/CMakeFiles/texelutil.dir/spsa.cpp.o -c /home/stepney141/board-games/texel/app/texelutil/spsa.cpp
[build] /home/stepney141/board-games/texel/app/texelutil/spsa.cpp:485:19: error: implicit instantiation of undefined template 'std::basic_ifstream<char>'
[build]     std::ifstream is(filename);
[build]                   ^
[build] /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/iosfwd:118:11: note: template is declared here
[build]     class basic_ifstream;
[build]           ^
[build] 1 error generated.
[build] ninja: build stopped: subcommand failed.
[proc] The command: /usr/bin/cmake --build /home/stepney141/board-games/texel/build --config Debug --target texelutil -- exited with code: 1
[driver] Build completed: 00:00:00.841
[build] Build finished with exit code 1
```